### PR TITLE
fix: prevent rules conflicts when you extend eslint:recommend or other rules

### DIFF
--- a/examples/vscode/.eslintrc.js
+++ b/examples/vscode/.eslintrc.js
@@ -16,4 +16,5 @@ module.exports = {
       }
     }
   ],
+  root: true
 }

--- a/examples/vscode/.eslintrc.js
+++ b/examples/vscode/.eslintrc.js
@@ -1,10 +1,19 @@
 module.exports = {
-  extends: ['plugin:@lint-md/recommend'],
-  // rules 覆盖
-  rules: {
-    '@lint-md/no-long-code': [2, {
-      "length": 10,
-      "exclude": []
-    }]
-  }
+  extends: [
+    'eslint:recommended'
+  ],
+  overrides: [
+    {
+      files: ['*.md'],
+      parser: '@lint-md/eslint-plugin/src/parser',
+      extends: ['plugin:@lint-md/recommend'],
+      rules: {
+        // 在这里覆盖已有的 rules
+        '@lint-md/no-long-code': [2, {
+          "length": 100,
+          "exclude": []
+        }]
+      }
+    }
+  ],
 }

--- a/examples/vscode/package.json
+++ b/examples/vscode/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "dependencies": {
     "eslint": "^7.21.0",
-    "@lint-md/eslint-plugin": "0.0.1"
+    "@lint-md/eslint-plugin": "0.0.2"
   },
   "scripts": {
     "lint": "eslint --ext .md ./"

--- a/examples/webstorm/.eslintrc.js
+++ b/examples/webstorm/.eslintrc.js
@@ -1,4 +1,20 @@
 module.exports = {
-  extends: ['plugin:@lint-md/recommend'],
+  extends: [
+    'eslint:recommended'
+  ],
+  overrides: [
+    {
+      files: ['*.md'],
+      parser: '@lint-md/eslint-plugin/src/parser',
+      extends: ['plugin:@lint-md/recommend'],
+      rules: {
+        // 在这里覆盖已有的 rules
+        '@lint-md/no-long-code': [2, {
+          "length": 100,
+          "exclude": []
+        }]
+      }
+    }
+  ],
   root: true
 }

--- a/examples/webstorm/package.json
+++ b/examples/webstorm/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "dependencies": {
     "eslint": "^7.21.0",
-    "@lint-md/eslint-plugin": "0.0.1"
+    "@lint-md/eslint-plugin": "0.0.2"
   },
   "scripts": {
     "lint": "eslint --ext .md ./"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lint-md/eslint-plugin",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "main": "src/index.js",
   "repository": "https://github.com/lint-md/eslint-plugin.git",
   "author": "yuzhanglong <yuzl1123@163.com>",

--- a/src/parser.js
+++ b/src/parser.js
@@ -36,7 +36,7 @@ module.exports = {
               1
             ],
             'expression': {
-              'type': 'Literal',
+              'type': 'MarkdownNode',
               'start': 0,
               'end': 1,
               'range': [

--- a/src/rule-template.js
+++ b/src/rule-template.js
@@ -24,7 +24,7 @@ module.exports = {
     }
 
     return {
-      Literal(node) {
+      MarkdownNode(node) {
         if (node.value) {
           // 调用 lint 函数
           const errors = lint(node.value)

--- a/src/rules/index.js
+++ b/src/rules/index.js
@@ -5,7 +5,7 @@
  *
  * Please refer to the lint-md documentation for details about this rule
  *
- * @created: Tue Mar 09 2021 
+ * @created: Thu Mar 11 2021 
  * @see: https://github.com/lint-md/lint-md
  */
 

--- a/src/rules/no-long-code.js
+++ b/src/rules/no-long-code.js
@@ -31,7 +31,7 @@ module.exports = {
   },
   create(context) {
     return {
-      Literal(node) {
+      MarkdownNode(node) {
         if (node.value) {
           // 调用 lint 函数
           const opt = Array.isArray(context.options) && context.options.length ? context.options[0] : {}


### PR DESCRIPTION
for #4 

其它 rules (例如 eslint-recommend) 会处理 md 文件 而导致 eslint error

解决方案：将 默认的 Literal 节点全部改成一个自定义的节点名称 **MarkdownNode**，防止其他 rules 遍历 Literal 节点时报错。
